### PR TITLE
Configuring TravisCI to only build for code related changes in PR or branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-script: [ "$(codeChangesAreMade.sh)" = "true" ] & ./runOnCICD.sh
+script: ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-script: ./runOnCICD.sh
+script: [ "$(codeChangesAreMade.sh)" = "true" ] & ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/codeChangesAreMade.sh
+++ b/codeChangesAreMade.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-git diff --name-only HEAD                     \
+git diff --name-only master                   \
      | perl -ne 'print $1 if m/\.([^.\/]+)$/' \
      | sort -u                                \
        > all-changed-files-extensions.txt

--- a/codeChangesAreMade.sh
+++ b/codeChangesAreMade.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+git diff --name-only master                   \
+     | perl -ne 'print $1 if m/\.([^.\/]+)$/' \
+     | sort -u                                \
+       > all-changed-files-extensions.txt
+
+EXCLUDE_EXTENSIONS=(rst md png jpeg jpg bmp gif)
+
+for EXT in "${EXCLUDE_EXTENSIONS[@]}"
+do
+	awk '!/'"${EXT}"'/' all-changed-files-extensions.txt > \
+	     temp && mv temp all-changed-files-extensions.txt
+done
+
+REMANINING_LINES=$(cat all-changed-files-extensions.txt | wc -l || true)
+
+CODE_CHANGES_DETECTED="false"
+if [[ ${REMANINING_LINES} -ne 0 ]]; then
+	CODE_CHANGES_DETECTED="true"
+fi
+
+rm -f all-changed-files-extensions.txt all-changed-files-extensions.txt.bak
+echo "${CODE_CHANGES_DETECTED}"

--- a/codeChangesAreMade.sh
+++ b/codeChangesAreMade.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-git diff --name-only master                   \
+git diff --name-only HEAD                     \
      | perl -ne 'print $1 if m/\.([^.\/]+)$/' \
      | sort -u                                \
        > all-changed-files-extensions.txt

--- a/runOnCICD.sh
+++ b/runOnCICD.sh
@@ -4,6 +4,11 @@ set -e
 set -u
 set -o pipefail
 
+if [[ "$(codeChangesAreMade.sh)" = "false" ]]; then
+   echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
+   exit 0
+fi
+
 echo "Running tox..."
 tox
 


### PR DESCRIPTION
Adding script and travis changes to see if the build is necessary due to code changes in project, skip build for non-code, docs or other types of changes

Resolves issue #51 