### PR TITLE
Optimise travisci trigger solution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-script: ./runOnCICD.sh
+script: [ "$(./codeChangesAreMade.sh)" = "true" ] && ./runOnCICD.sh || echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script: |
      ./runOnCICD.sh; 
   else 
      echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch.";
+     exit 0;
   fi
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ python:
 - 3.7
 - 3.6
 - 3.5
-before_install: export CODE_CHANGES="$(./codeChangesAreMade.sh)"
-install: pip install -U tox-travis
-script: | 
-  echo "CODE_CHANGES: ${CODE_CHANGES:-}"
-  if [[ "${CODE_CHANGES}" = "true" ]]; then
-     ./runOnCICD.sh; 
-  else 
+before_install: | 
+  export CODE_CHANGES="$(./codeChangesAreMade.sh)"
+  CODE_CHANGES=${CODE_CHANGES:-}
+  echo "CODE_CHANGES: ${CODE_CHANGES}"
+  if [[ "${CODE_CHANGES}" = "false" ]]; then
      echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch.";
      exit 0;
   fi
+install: pip install -U tox-travis
+script: ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-env: CODE_CHANGES="$(./codeChangesAreMade.sh)"
-if: env(CODE_CHANGES) = true
-script: ./runOnCICD.sh
+script: | 
+  CODE_CHANGES="$(./codeChangesAreMade.sh)"
+  if [[ "${CODE_CHANGES}" == "true" ]]; then
+     ./runOnCICD.sh; 
+  else 
+     echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch.";
+  fi
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-script: [ "$(./codeChangesAreMade.sh)" = "true" ] && ./runOnCICD.sh || echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
+if: "$(./codeChangesAreMade.sh)" = "true"
+script: ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install: pip install -U tox-travis
 script: | 
   CODE_CHANGES="$(./codeChangesAreMade.sh)"
-  if [[ "${CODE_CHANGES}" == "true" ]]; then
+  if [[ "${CODE_CHANGES}" = "true" ]]; then
      ./runOnCICD.sh; 
   else 
      echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch.";

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-if: "$(./codeChangesAreMade.sh)" = "true"
-script: ./runOnCICD.sh
+script: 
+- export CODE_CHANGES="$(./codeChangesAreMade.sh)"
+- [ "${CODE_CHANGES}" = "true" ] && echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
+- ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ python:
 - 3.6
 - 3.5
 install: pip install -U tox-travis
-script: 
-- export CODE_CHANGES="$(./codeChangesAreMade.sh)"
-- [ "${CODE_CHANGES}" = "true" ] && echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
-- ./runOnCICD.sh
+env: CODE_CHANGES="$(./codeChangesAreMade.sh)"
+if: env(CODE_CHANGES) = true
+script: ./runOnCICD.sh
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
 - 3.7
 - 3.6
 - 3.5
+before_install: export CODE_CHANGES="$(./codeChangesAreMade.sh)"
 install: pip install -U tox-travis
 script: | 
-  CODE_CHANGES="$(./codeChangesAreMade.sh)"
+  echo "CODE_CHANGES: ${CODE_CHANGES:-}"
   if [[ "${CODE_CHANGES}" = "true" ]]; then
      ./runOnCICD.sh; 
   else 

--- a/runOnCICD.sh
+++ b/runOnCICD.sh
@@ -4,11 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-if [[ "$(./codeChangesAreMade.sh)" = "false" ]]; then
-   echo "We have not made code related changes in this PR/branch, hence exiting gracefully now. No TravisCI build will be triggered for this PR/branch."
-   exit 0
-fi
-
 echo "Running tox..."
 tox
 


### PR DESCRIPTION
Move the logic of checking for code-related file changes in PR/Branch into the .travis.yml file from the runOnCICD.sh script

On the back of #51, this PR/branch **will build** as two source code related files have been changed, otherwise, there is something wrong and needs debugging.

Tested via PR  #64