### PR TITLE
[Doc] #74 Improving CONTRIBUTING.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ Contributors
 * Przemyslaw Pietras <https://github.com/destag>
 * Ignacio Pacheco <https://github.com/ipacheco-uy>
 * TenebraeX8 <https://github.com/TenebraeX8>
+* Faraz Fesharaki <farazfesharaki2000@yahoo.com>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,5 @@
+.. contents:: :local:
+
 .. highlight:: shell
 
 ============
@@ -125,14 +127,6 @@ Before you submit a pull request, check that it meets these guidelines:
   * [Doc] for documentation
   * [BUG] for bug fix
   * [WIP] for work in progress PR
-
-Tips
-----
-
-To run a subset of tests::
-
-$ pytest tests.test_picknmix
-
 
 Deploying
 ---------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -124,9 +124,10 @@ Before you submit a pull request, check that it meets these guidelines:
    https://travis-ci.org/Cheukting/picknmix/pull_requests
    and make sure that the tests pass for all supported Python versions.
 4. Use this title convention::
-  * [Doc] for documentation
-  * [BUG] for bug fix
-  * [WIP] for work in progress PR
+
+   * [Doc] for documentation
+   * [BUG] for bug fix
+   * [WIP] for work in progress PR
 
 Deploying
 ---------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,6 @@ Welcome to Pick n Mix's documentation!
    readme
    installation
    usage
-   modules
    contributing
    authors
    history


### PR DESCRIPTION
Section Tips removed in response to issue #74 
A local table of contents added in response to issue #74 
Fixed below warnings in the process of building docs:
    
    Literal block expected; none found. 

    html_static_path entry '_static' does not exist

    toctree contains reference to nonexisting document 'modules'

    Enumerated list ends without a blank line; unexpected unindent.

